### PR TITLE
fix: SQL issue in production

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "langfuse>=2.60.7",
     "llama-cloud-services>=0.6.25",
     "openai>=1.82.1",
+    "pysqlite3-binary>=0.5.4",
     "streamlit>=1.45.1",
     "tiktoken>=0.9.0",
 ]

--- a/src/ui/chatbot.py
+++ b/src/ui/chatbot.py
@@ -1,4 +1,13 @@
+import sys
 import uuid
+
+# Fix for ChromaDB SQLite compatibility on Streamlit Cloud
+try:
+    import pysqlite3
+
+    sys.modules["sqlite3"] = pysqlite3
+except ImportError:
+    pass
 
 import chromadb
 import streamlit as st

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -1,3 +1,13 @@
+import sys
+
+# Fix for ChromaDB SQLite compatibility on Streamlit Cloud
+try:
+    import pysqlite3
+
+    sys.modules["sqlite3"] = pysqlite3
+except ImportError:
+    pass
+
 import chromadb
 import streamlit as st
 import tiktoken

--- a/uv.lock
+++ b/uv.lock
@@ -375,13 +375,14 @@ wheels = [
 
 [[package]]
 name = "disaster-rag-assistant"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "chromadb" },
     { name = "langfuse" },
     { name = "llama-cloud-services" },
     { name = "openai" },
+    { name = "pysqlite3-binary" },
     { name = "streamlit" },
     { name = "tiktoken" },
 ]
@@ -392,6 +393,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=2.60.7" },
     { name = "llama-cloud-services", specifier = ">=0.6.25" },
     { name = "openai", specifier = ">=1.82.1" },
+    { name = "pysqlite3-binary", specifier = ">=0.5.4" },
     { name = "streamlit", specifier = ">=1.45.1" },
     { name = "tiktoken", specifier = ">=0.9.0" },
 ]
@@ -1646,6 +1648,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pysqlite3-binary"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/ed/f6638728ea46bf90f0fba63d7f53a57cbab1ba7d34a1eb86419ca582a797/pysqlite3_binary-0.5.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb3653a0eb0ef5db2d0ed49d43b11ab4be24fdf5b2e65a39650fc59348e30dc6", size = 5188499, upload-time = "2024-10-12T12:46:21.926Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
this pr fixes the following error in prod 
```bash
RuntimeError: �[91mYour system has an unsupported version of sqlite3. Chroma requires sqlite3 >= 3.35.0.�[0m
```

by adding the dependency pysqlite3-binary.

https://docs.trychroma.com/updates/troubleshooting#sqlite
